### PR TITLE
Fixed crash when using camera since options was defaulted to null since it wasn't passed through.

### DIFF
--- a/MonoTouch/Xamarin.Mobile/Media/MediaPicker.cs
+++ b/MonoTouch/Xamarin.Mobile/Media/MediaPicker.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Media
 			if (od != null)
 				throw new InvalidOperationException ("Only one operation can be active at at time");
 
-			var picker = SetupController (ndelegate, sourceType, mediaType);
+			var picker = SetupController (ndelegate, sourceType, mediaType, options);
 
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad) {	
 				ndelegate.Popover = new UIPopoverController (picker);


### PR DESCRIPTION
This fixes a crash for source type of camera since if you don't pass options through it will crash when it tries to reference the property options.DefaultCamera

e.g. 
-      var picker = SetupController (ndelegate, sourceType, mediaType);
-      var picker = SetupController (ndelegate, sourceType, mediaType, options);

And then in SetupController would crash on the second line below:
if (sourceType == UIImagePickerControllerSourceType.Camera) {
                picker.CameraDevice = GetUICameraDevice (options.DefaultCamera);
