### PR TITLE
Don't wait for heading information if it hasn't been requested

### DIFF
--- a/MonoTouch/Xamarin.Mobile/Geolocation/GeolocationSingleUpdateDelegate.cs
+++ b/MonoTouch/Xamarin.Mobile/Geolocation/GeolocationSingleUpdateDelegate.cs
@@ -24,11 +24,12 @@ namespace Xamarin.Geolocation
 	internal class GeolocationSingleUpdateDelegate
 		: CLLocationManagerDelegate
 	{
-		public GeolocationSingleUpdateDelegate (CLLocationManager manager, double desiredAccuracy, int timeout, CancellationToken cancelToken)
+		public GeolocationSingleUpdateDelegate (CLLocationManager manager, double desiredAccuracy, bool includeHeading, int timeout, CancellationToken cancelToken)
 		{
 			this.manager = manager;
 			this.tcs = new TaskCompletionSource<Position> (manager);
 			this.desiredAccuracy = desiredAccuracy;
+			this.includeHeading = includeHeading;
 			
 			if (timeout != Timeout.Infinite)
 			{
@@ -100,7 +101,7 @@ namespace Xamarin.Geolocation
 
 			this.haveLocation = true;
 			
-			if (this.haveHeading && this.position.Accuracy <= this.desiredAccuracy)
+			if ((!this.includeHeading || this.haveHeading) && this.position.Accuracy <= this.desiredAccuracy)
 			{
 				this.tcs.TrySetResult (new Position (this.position));
 				StopListening();
@@ -131,6 +132,7 @@ namespace Xamarin.Geolocation
 		private CLHeading bestHeading;
 
 		private readonly double desiredAccuracy;
+		private readonly bool includeHeading;
 		private readonly TaskCompletionSource<Position> tcs;
 		private readonly CLLocationManager manager;
 		

--- a/MonoTouch/Xamarin.Mobile/Geolocation/Geolocator.cs
+++ b/MonoTouch/Xamarin.Mobile/Geolocation/Geolocator.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Geolocation
 				var m = GetManager();
 
 				tcs = new TaskCompletionSource<Position> (m);
-				var singleListener = new GeolocationSingleUpdateDelegate (m, DesiredAccuracy, timeout, cancelToken);
+				var singleListener = new GeolocationSingleUpdateDelegate (m, DesiredAccuracy, includeHeading, timeout, cancelToken);
 				m.Delegate = singleListener;
 
 				m.StartUpdatingLocation ();


### PR DESCRIPTION
This fixes a bug we were seeing where the geolocator would always wait until the timeout is exceeded. This happens if you don't request heading information, and so the position data isn't delivered until the timeout.
