### PR TITLE
Use Extras to specify the location for videos to be recorded; Move them only if necessary

### DIFF
--- a/MonoDroid/Xamarin.Mobile/Media/MediaPickerActivity.cs
+++ b/MonoDroid/Xamarin.Mobile/Media/MediaPickerActivity.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Media
 					else
 						this.path = Uri.Parse (b.GetString (ExtraPath));
 
-					if (this.isPhoto && !ran)
+					if (!ran)
 					{
 						Touch();
 						pickIntent.PutExtra (MediaStore.ExtraOutput, this.path);
@@ -216,6 +216,12 @@ namespace Xamarin.Media
 		
 		private static Task<bool> TryMoveFileAsync (Context context, Uri url, Uri path, bool isPhoto)
 		{
+		    if (url.Equals(path))
+		    {
+		        var tcs = new TaskCompletionSource<bool>();
+                tcs.SetResult(true);
+		        return tcs.Task;
+		    }
 			string moveTo = GetLocalPath (path);
 			return GetFileForUriAsync (context, url, isPhoto).ContinueWith (t => {
 				if (t.Result.Item1 == null)


### PR DESCRIPTION
On the Nexus 7 (and likely other devices), recording a video would always return a MediaFile that didn't exist.
