### PR TITLE
Use original image instead of re-encoding as max quality JPEG

### DIFF
--- a/Shared/Media/StoreMediaOptions.cs
+++ b/Shared/Media/StoreMediaOptions.cs
@@ -46,7 +46,20 @@ namespace Xamarin.Media
 	public class StoreCameraMediaOptions
 		: StoreMediaOptions
 	{
+		public StoreCameraMediaOptions()
+		{
+			// 0.90 produces an image quality of 96 according to ImageMagick's identify -verbose
+			// which is equivalent to the default compression quality used by the Camera app
+			JpegCompressionQuality = 0.90f;
+		}
+
 		public CameraDevice DefaultCamera
+		{
+			get;
+			set;
+		}
+
+		public float JpegCompressionQuality
 		{
 			get;
 			set;


### PR DESCRIPTION
MediaPicker was using UIImage.AsJPEG() to save the image picked from the camera roll.  This re-encodes the image with maximum JPEG quality, resulting in an approximate doubling of the file size and loss of the original EXIF data.

This PR makes an exact copy of the original file from the asset library unless an edited version of the image exists, in which case it still uses UIImage.AsJPEG() since that is the only way to get the edited version of the image data.

I have tested and confirmed that this fix preserves the original file size and EXIF data for unedited images.
