### PR TITLE
Reset the TaskCompletionSource so the picker instance can be reused

### DIFF
--- a/MonoTouch/Xamarin.Mobile/Media/MediaPickerDelegate.cs
+++ b/MonoTouch/Xamarin.Mobile/Media/MediaPickerDelegate.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Media
 		private NSObject observer;
 		private readonly UIViewController viewController;
 		private readonly UIImagePickerControllerSourceType source;
-		private readonly TaskCompletionSource<MediaFile> tcs = new TaskCompletionSource<MediaFile>();
+		private TaskCompletionSource<MediaFile> tcs = new TaskCompletionSource<MediaFile>();
 		private readonly StoreCameraMediaOptions options;
 
 		private bool IsCaptured
@@ -143,8 +143,10 @@ namespace Xamarin.Media
 		
 		private void Dismiss (UIImagePickerController picker, NSAction onDismiss)
 		{
-			if (this.viewController == null)
-				onDismiss();
+            if (this.viewController == null) {
+                onDismiss();
+                tcs = new TaskCompletionSource<MediaFile>();
+            }
 			else {
 				NSNotificationCenter.DefaultCenter.RemoveObserver (this.observer);
 				UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();


### PR DESCRIPTION
Applies to scenarios where the client code uses GetPickPhotoUI/GetTakePhotoUI to generate a view controller instance. The "tcs" field is reset on Dismiss so the same instance can be reused in the navigation controller stack. This enables scenarios where after picking media a custom ViewController is pushed onto the picker's stack, and the user goes "Back" to the picker controllers.