### PR TITLE
Added support for building everything on Windows

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -67,6 +67,21 @@ Task ("samples").IsDependentOn ("libs").Does (() =>
 
 		MSBuild ("./WindowsRT/Samples/GeolocationSample/GeolocationSample.csproj", c => c.SetConfiguration("Release").SetPlatformTarget(PlatformTarget.x86));
 		MSBuild ("./WindowsRT/Samples/MediaPickerSample/MediaPickerSample.csproj", c => c.SetConfiguration("Release").SetPlatformTarget(PlatformTarget.x86));
+        
+        if (PLATFORMPROJECTS == "Everything") {
+            
+            MSBuild ("./MonoDroid/Samples/ContactsSample/Contacts Sample.csproj", c => c.SetConfiguration("Release"));
+            MSBuild ("./MonoDroid/Samples/GeolocationSample/Geolocation Sample.csproj", c => c.SetConfiguration("Release"));
+            MSBuild ("./MonoDroid/Samples/MediaPickerSample/MediaPicker Sample.csproj", c => c.SetConfiguration("Release"));
+
+            MSBuild ("./MonoTouch/Samples/ContactsSample/Contacts Sample.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            MSBuild ("./MonoTouch/Samples/Geolocation/Geolocation Sample.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            MSBuild ("./MonoTouch/Samples/MediaPickerSample/MediaPicker Sample.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+
+            MSBuild ("./MonoTouch/Samples/ContactsSample-Classic/Contacts Sample-Classic.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            MSBuild ("./MonoTouch/Samples/Geolocation-Classic/Geolocation Sample-Classic.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            MSBuild ("./MonoTouch/Samples/MediaPickerSample-Classic/MediaPicker Sample-Classic.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+        }
 	} else {		
 		DotNetBuild ("./MonoDroid/Samples/ContactsSample/Contacts Sample.csproj", c => c.Configuration = "Release");
 		DotNetBuild ("./MonoDroid/Samples/GeolocationSample/Geolocation Sample.csproj", c => c.Configuration = "Release");

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 #addin "Cake.Xamarin"
 
 var TARGET = Argument ("t", Argument ("target", Argument ("Target", "Default")));
+var PLATFORMPROJECTS = Argument ("platformprojects", Argument ("PlatformProjects", "Platform"));
 
 Task ("libs").Does (() => 
 {
@@ -17,6 +18,24 @@ Task ("libs").Does (() =>
 
 		MSBuild ("./WindowsRT/Xamarin.Mobile/Xamarin.Mobile.csproj", c => c.SetConfiguration("Release").SetPlatformTarget(PlatformTarget.x86));
 		CopyFiles ("./WindowsRT/Xamarin.Mobile/bin/**/Release/*.dll", "./output/winrt");
+        
+        if (PLATFORMPROJECTS == "Everything") {
+            
+            CreateDirectory ("./output/android/");
+            CreateDirectory ("./output/ios-unified/");
+            CreateDirectory ("./output/ios/");
+
+            NuGetRestore ("./Xamarin.Mobile.Mac.sln");
+
+            MSBuild ("./MonoDroid/Xamarin.Mobile/Xamarin.Mobile.Android.csproj", c => c.SetConfiguration("Release"));
+            CopyFiles ("./MonoDroid/Xamarin.Mobile/bin/Release/*.dll", "./output/android");
+
+            MSBuild ("./MonoTouch/Xamarin.Mobile/Xamarin.Mobile.iOS.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            CopyFiles ("./MonoTouch/Xamarin.Mobile/bin/unified/iPhone/Release/*.dll", "./output/ios-unified");
+
+            MSBuild ("./MonoTouch/Xamarin.Mobile/Xamarin.Mobile.iOS-Classic.csproj", c => c.SetConfiguration("Release").WithProperty("Platform", "iPhone"));
+            CopyFiles ("./MonoTouch/Xamarin.Mobile/bin/classic/iPhone/Release/*.dll", "./output/ios");
+        }
 
 	} else {
 

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,9 @@ Param(
     [string]$Verbosity = "Verbose",
     [switch]$Experimental,
     [Alias("DryRun","Noop")]
-    [switch]$WhatIf
+    [switch]$WhatIf,
+    [ValidateSet("Platform", "Everything")]
+    [string]$PlatformProjects = "Platform"
 )
 
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
@@ -70,5 +72,5 @@ if (!(Test-Path $CAKE_EXE)) {
 }
 
 # Start Cake
-Invoke-Expression "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseDryRun $UseExperimental"
+Invoke-Expression "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" -platformprojects=`"$PlatformProjects`" $UseDryRun $UseExperimental"
 exit $LASTEXITCODE


### PR DESCRIPTION
An optional extra parameter that allows Windows build machines to build the Xamarin platforms:

```
.\build.ps1 -PlatformProjects Everything
```

This is optional and only available on Windows. It uses MSBuild and requires the iOS build host.
